### PR TITLE
Updated gunscript

### DIFF
--- a/BigaJam#2Game/Assets/Scripts/PlayerStats.cs
+++ b/BigaJam#2Game/Assets/Scripts/PlayerStats.cs
@@ -8,6 +8,7 @@ public class PlayerStats : MonoBehaviour
 {
     #region Fields
     [Header("Max Values")]
+    [SerializeField] bool _HasInfiniteAmmo = false;
     [Min(0)]
     [SerializeField] int _MaxAmmo = 100;
     [Min(0)]
@@ -157,6 +158,10 @@ public class PlayerStats : MonoBehaviour
 
         return amount >= 0;
     }
+
+
+
+    public bool HasInfiniteAmmo { get { return _HasInfiniteAmmo; } }
 
     #endregion
 }

--- a/BigaJam#2Game/Assets/Scripts/ShootingSystem/GunScript.cs
+++ b/BigaJam#2Game/Assets/Scripts/ShootingSystem/GunScript.cs
@@ -90,9 +90,9 @@ public class GunScript : MonoBehaviour
     //--------------Function for shooting--------------\\
     void Shoot(InputAction.CallbackContext ctx)
     {
-        if (_playerStats.Ammo > 0)
+        if (_gunAmmo > 0)
         {
-            _playerStats.RemoveAmmo(1);
+            _gunAmmo--;
             _pool.GetFreeElement(_bulletSpawnPos.position, _bulletSpawnPos.rotation);
             _anim.SetTrigger("Shoot");
         }
@@ -102,6 +102,17 @@ public class GunScript : MonoBehaviour
     {
         if (_canReload)
         {
+            if (_playerStats.HasInfiniteAmmo || _playerStats.Ammo >= _gunMaxAmmo)
+            {
+                _gunAmmo = _gunMaxAmmo;
+                _playerStats.RemoveAmmo(_gunMaxAmmo);
+            }
+            else if (_playerStats.Ammo > 0)
+            {
+                _gunAmmo = _playerStats.Ammo;
+                _playerStats.RemoveAmmo(_playerStats.Ammo);
+            }
+
             _playerStats.AddAmmo(_gunMaxAmmo);
             _canReload = false;
             Invoke("UnlockReload", 5.0f);


### PR DESCRIPTION
GunScript had bug where it was just using playerStats.ammo. I changed it so reload pulls maxAmmo from playerStats and puts it in gunAmmo, which is now used when you shoot. I also added a hasInfiniteAmmo property to PlayerStats, so you can make each player have infinite ammo like they did before super easily.